### PR TITLE
add support for smpte (legal) range output from odt_rec709.ctl

### DIFF
--- a/transforms/ctl/odt/rec709/odt_rec709.ctl
+++ b/transforms/ctl/odt/rec709/odt_rec709.ctl
@@ -65,6 +65,13 @@
 //		of a motion picture theater.  This ODT makes no attempt to compensate for 
 //		viewing environment variables more typical of those associated with the home.
 //
+// By default this transform outputs full range code values. If smpte (legal) range code
+// values are desired the default can be overridden at runtime by setting the input 
+// variable smpteRangeOut equal to true.
+//
+// Example: 
+// ctlrender -ctl odt_rec709.ctl -param1 smpteRangeOut 1.0 oces.exr image709legal.tif
+//
 
 
 
@@ -98,7 +105,8 @@ void main
 	output varying float rOut,
 	output varying float gOut,
 	output varying float bOut,
-	output varying float aOut
+	output varying float aOut,
+	input uniform bool smpteRangeOut = false
 )
 {
 	float oces[3] = {rIn, gIn, bIn};
@@ -138,4 +146,14 @@ void main
 	gOut = ( pow( RGBo[1],(1.0/GAMMA)) / A ) - B;
 	bOut = ( pow( RGBo[2],(1.0/GAMMA)) / A ) - B;	
 	aOut = aIn;
+	
+	if (smpteRangeOut == true) {
+	
+		float fullRange[3] = {rOut, gOut, bOut};
+		float smpteRange[3] = fullRange_to_smpteRange( fullRange );
+		
+		rOut = smpteRange[0];
+		gOut = smpteRange[1];
+		bOut = smpteRange[2];	
+	}	
 }

--- a/transforms/ctl/utilities/utilities.ctl
+++ b/transforms/ctl/utilities/utilities.ctl
@@ -318,33 +318,33 @@ void ratio_preserving_odt_tonecurve
 	rgbOut[2] = ( 1. - d) * rgbOut[2] + d * normRGBo;
 }
 
-void smpteRange_to_fullRange
-( 	input varying float rgbIn[3],
-	output varying float rgbOut[3] 
-)
+float[3] smpteRange_to_fullRange( varying float rgbIn[3] )
 { 
 
 	const float REFWHITE = ( 940.0 / 1023.0);
 	const float REFBLACK = (  64.0 / 1023.0);
 	
+	float rgbOut[3];
 	rgbOut[0] = ( rgbIn[0] - REFBLACK) / ( REFWHITE - REFBLACK);
 	rgbOut[1] = ( rgbIn[1] - REFBLACK) / ( REFWHITE - REFBLACK);
 	rgbOut[2] = ( rgbIn[2] - REFBLACK) / ( REFWHITE - REFBLACK);
+	
+	return rgbOut;
 
 }
 
-void fullRange_to_smpteRange
-( 	input varying float rgbIn[3],
-	output varying float rgbOut[3] 
-)
+float[3] fullRange_to_smpteRange( varying float rgbIn[3] )
 { 
 
 	const float REFWHITE = ( 940.0 / 1023.0);
 	const float REFBLACK = (  64.0 / 1023.0);
 	
+	float rgbOut[3];
 	rgbOut[0] = rgbIn[0]  * ( REFWHITE - REFBLACK) + REFBLACK;
 	rgbOut[1] = rgbIn[1]  * ( REFWHITE - REFBLACK) + REFBLACK;
 	rgbOut[2] = rgbIn[2]  * ( REFWHITE - REFBLACK) + REFBLACK;
+	
+	return rgbOut;
 
 }
 


### PR DESCRIPTION
- default code value range from odt_rec709 is full range.  Legal range output can be achieved using smpteRangeOut input variable.
- modifies utilities.ctl functions smpteRange_to_fullRange and fullRange_to_smpteRange from type void to type float[3]
