### PR TITLE
add documentation on assumed observer adapted white point to odt transforms

### DIFF
--- a/transforms/ctl/odt/p3d60/odt_p3d60.ctl
+++ b/transforms/ctl/odt/p3d60/odt_p3d60.ctl
@@ -62,6 +62,10 @@
 //                            Blue:    0.15         0.06
 //                           White:    0.32168      0.33767     48cd/m^2
 //
+// Assumed observer adapted white point:
+//         CIE 1931 chromaticity:        x            y
+//                                     0.32168      0.33767
+//
 // Display EOTF :
 //		Gamma: 2.6
 //		Offset: 0.0

--- a/transforms/ctl/odt/p3dci/odt_p3dci.ctl
+++ b/transforms/ctl/odt/p3dci/odt_p3dci.ctl
@@ -62,6 +62,10 @@
 //                            Blue:    0.15         0.06
 //                           White:    0.314        0.351       48cd/m^2
 //
+// Assumed observer adapted white point:
+//         CIE 1931 chromaticity:        x            y
+//                                     0.32168      0.33767
+//
 // Display EOTF :
 //		Gamma: 2.6
 //		Offset: 0.0

--- a/transforms/ctl/odt/rec709/odt_rec709.ctl
+++ b/transforms/ctl/odt/rec709/odt_rec709.ctl
@@ -55,6 +55,9 @@
 // reference OETF specified in Rec. ITU-R BT.1886 and primaries specified in 
 // Rec. ITU-R BT.709.
 //
+// The assumed observer adapted white point shall be the chromaticity coordinates 
+// specified for white in Rec. ITU-R BT.709.
+//
 // This transform shall be used with a device calibrated to match the primaries
 // specified Rec. ITU-R BT.709 and reference electro-optical transfer function 
 // specified in Rec. ITU-R BT.1886 where L = 100 cd/m^2 Lw = 1.0 and Lb = 0.0 .

--- a/transforms/ctl/odt/sRGB/odt_sRGB.ctl
+++ b/transforms/ctl/odt/sRGB/odt_sRGB.ctl
@@ -56,6 +56,9 @@
 // This transform shall be used with a device calibrated to match the reference computer
 // monitor specified in IEC 61966-2-1:1999. 
 //
+// The assumed observer adapted white point shall be the chromaticity coordinates 
+// specified for white in IEC 61966-2-1:1999.
+//
 // Viewing Environment:
 // 		Environment specified in SMPTE RP 431-2-2007
 //		Note: This environement is consistent with the viewing environment typical

--- a/transforms/ctl/odt/smpte_rp/rdt_dcdm.ctl
+++ b/transforms/ctl/odt/smpte_rp/rdt_dcdm.ctl
@@ -56,6 +56,10 @@
 // This transform shall be used for a device calibrated to match the Digital Cinema
 // Reference Projector Specification outlined in SMPTE RP 431-2-2007.
 //
+// Assumed observer adapted white point:
+//         CIE 1931 chromaticity:        x            y
+//                                     0.32168      0.33767
+//
 // Viewing Environment:
 // 		Environment specified in SMPTE RP 431-2-2007
 //


### PR DESCRIPTION
documentation clarifies white point handling methodology between OCES and device code values.
