### PR TITLE
fix for [issue 7].

### DIFF
--- a/apps/ctlrender/src/ctl/IlmCtlSimd/CtlSimdReg.cpp
+++ b/apps/ctlrender/src/ctl/IlmCtlSimd/CtlSimdReg.cpp
@@ -108,6 +108,7 @@ SimdReg::SimdReg
 	{
 	    for( int i = 0; i < (int)regSize; i++ )
 	    {
+	    if( !mask[i] ) continue;
 		int ind = *(int *)(indReg[i]);
 		if( ind < 0 || ind >= (int)arraySize )
 		    throwIndexOutOfRange (ind, arraySize);
@@ -121,6 +122,7 @@ SimdReg::SimdReg
 	{
 	    for( int i = 0; i < (int)regSize; i++ )
 	    {
+	    if( !mask[i] ) continue;
 		int ind = *(int *)(indReg[i]);
 		if( ind < 0 || ind >= (int)arraySize )
 		    throwIndexOutOfRange (ind, arraySize);


### PR DESCRIPTION
There were a couple places with code similar to this:

``` c++
int ind = *(int *)(indReg[i]);
if( ind < 0 || ind >= (int)arraySize )
  throwIndexOutOfRange (ind, arraySize);

if( mask[i] )
  _offsets[i] = r._offsets[0] + ind*arrayElementSize;
```

The issue with that is that when ctl code has multiple paths for varying variables not every index is valid. So in this case the code checks to see if something is out of range before it checks to see if that index is even valid for the current path. All I did was add the check `if (!mask[i] ) continue` to skip the code and out of range check when the value was invalid anyway.
