### PR TITLE
fix for issue #5

### DIFF
--- a/apps/ctlrender/src/ctl/IlmCtl/CtlFunctionCall.cpp
+++ b/apps/ctlrender/src/ctl/IlmCtl/CtlFunctionCall.cpp
@@ -123,7 +123,7 @@ FunctionCall::setReturnValue (const FunctionArgPtr &rval)
 
 FunctionArg::FunctionArg
     (const string &name,
-     const FunctionCallPtr &func,
+     FunctionCall* func,
      const DataTypePtr &type,
      bool varying)
 :

--- a/apps/ctlrender/src/ctl/IlmCtl/CtlFunctionCall.h
+++ b/apps/ctlrender/src/ctl/IlmCtl/CtlFunctionCall.h
@@ -178,7 +178,7 @@ class FunctionArg: public TypeStorage {
     //-------------------------------------------------------------
 
     FunctionArg(const std::string &name,
-	            const FunctionCallPtr &func,
+	            FunctionCall* func,
 	            const DataTypePtr &type,
 	            bool varying);
 
@@ -189,7 +189,7 @@ class FunctionArg: public TypeStorage {
     // The FunctionCall object to which this FunctionArg belongs
     //----------------------------------------------------------
 
-    const FunctionCallPtr &	func () const		{return _func;}
+    const FunctionCall*	func () const		{return _func;}
 
 
     //-----------------------------------------------------------------
@@ -223,7 +223,7 @@ class FunctionArg: public TypeStorage {
     virtual void		setDefaultValue () = 0;
 
   private:
-    FunctionCallPtr		_func;
+    FunctionCall*		_func;
     bool                _varying;
 };
 

--- a/apps/ctlrender/src/ctl/IlmCtlSimd/CtlSimdFunctionCall.cpp
+++ b/apps/ctlrender/src/ctl/IlmCtlSimd/CtlSimdFunctionCall.cpp
@@ -177,7 +177,7 @@ SimdFunctionCall::callFunction (size_t numSamples)
 
 SimdFunctionArg::SimdFunctionArg
     (const std::string &name,
-     const FunctionCallPtr &func,
+     FunctionCall* func,
      const DataTypePtr &type,
      bool varying,
      SimdReg *reg)
@@ -189,7 +189,7 @@ SimdFunctionArg::SimdFunctionArg
     // Find the register associated with the parameter default value
     string staticName = func->name() + "$" + name;
 
-    SimdFunctionCallPtr sfunc(func);
+    SimdFunctionCall* sfunc = static_cast<SimdFunctionCall*>(func);
     SymbolInfoPtr info = sfunc->symbols().lookupSymbol( staticName );
     if( info )
     {
@@ -248,9 +248,12 @@ SimdFunctionArg::setVarying(bool varying)
 }
 
 size_t SimdFunctionArg::elements(void) const {
-	SimdFunctionCallPtr fc(func());
-
-	return fc->xContext()->interpreter().maxSamples();
+	// reason for casting here is that _func is private to FunctionArg
+	// the public function func() returns a const FunctionCall*
+	// should func return non-const or should _func be promoted to protected?
+	return const_cast<SimdFunctionCall*>(
+	static_cast<const SimdFunctionCall*>(func())
+	)->xContext()->interpreter().maxSamples();
 }
 
 } // namespace Ctl

--- a/apps/ctlrender/src/ctl/IlmCtlSimd/CtlSimdFunctionCall.h
+++ b/apps/ctlrender/src/ctl/IlmCtlSimd/CtlSimdFunctionCall.h
@@ -95,7 +95,7 @@ class SimdFunctionArg: public FunctionArg
   public:
 
     SimdFunctionArg (const std::string &name,
-		     const FunctionCallPtr &func,
+		     FunctionCall* func,
 		     const DataTypePtr &type,
 		     bool varying,
 		     SimdReg *reg);


### PR DESCRIPTION
all memory deallocation seems to be handled by reference counting. Specifically RcObjects are pointed to by RcPtr which will destroy the object once the last pointer goes out of scope.
1. Once a module is loaded a new function needs to be created.
2. FunctionCallPtr fn = interpreter.newFunctionCall("funcName");
3. This ensures the function can be called from C++ and if so calls newFunctionInternal
4. which allocates a new SimdFunctionCall object.
5. The constructor now allocates several objects of SimdFunctionArg.

This is where is gets tricky. SimdFunctionArg takes a FunctionCallPtr as it's parameter. So SimdFunctionCall passes a pointer to itself (this) which is then counted by RcPtr and owned by SimdFunctionArg in turn owned by SimdFunctionCall. Essentially this means SimdFunctionCall owns reference counts to itself. So how does SimdFunctionCall ever get released?
1. A FunctionCallPtr is returned
2. FunctionCall is used (call/run/return)
3. FunctionCallPtr goes out of scope
4. Memory is lost

Since SimdFunctionArg is only used in SimdFunctionCall, I fixed the issue by changing all FunctionCallPtr types in SimdFunctionArg to actual pointers (SimdFunctionCall*). Now SimdFunctionArg does not own a reference to SimdFunctionCall which is okay because SimdFunctionCall's lifetime exceeds SimdFunctionArg's lifetime. In turn SimdFunctionCall no longer holds a hidden reference count to itself and is correctly freed when needed.
