### PR TITLE
add Canon IDTs as CTL and update README

### DIFF
--- a/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_BT2020_D55.a1.v2.ctl
+++ b/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_BT2020_D55.a1.v2.ctl
@@ -1,0 +1,73 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_BT2020_D55.a1.v2</ACEStransformID>
+// <ACESuserName>ACES 1.0 Input - Canon CanonLog2 BT2020 (Daylight)</ACESuserName>
+
+/* ********************************************* */
+//
+// Input Transform for Canon Log 2 / BT.2020
+// ACES Version: 1.0
+// IDT Version: 2.0  2021/08/23
+// Copyright(c) 2021 Canon Inc. All Rights Reserved.
+//
+/* ********************************************* */
+//
+// Illuminant   : Daylight (CIE Illuminant D55)
+// Color Gamut  : BT.2020
+// Gamma        : Canon Log 2
+// Color Matrix : Neutral
+//
+// [ NOTE ]
+//
+// This Input Transform is defined for images those were shot
+//  under daylight and general illumination sources except Tungsten.
+//
+/* ********************************************* */
+
+
+/* ============ SUBFUNCTIONS ============ */
+/* CanonLog2 to Linear */
+float CanonLog2_to_linear (
+	float clog2
+)
+{
+	float out;
+	if(clog2 < 0.092864125)
+		out = -( pow( 10, ( 0.092864125 - clog2 ) / 0.24136077 ) - 1 ) / 87.099375;
+	else
+		out = ( pow( 10, ( clog2 - 0.092864125 ) / 0.24136077 ) - 1 ) / 87.099375;
+
+	return out;
+}
+
+
+/* ============ Main Algorithm ============ */
+void main
+(   input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+	// CanonLog2 to linear 
+	float lin[3];
+	lin[0] = 0.9 * CanonLog2_to_linear( rIn );
+	lin[1] = 0.9 * CanonLog2_to_linear( gIn );
+	lin[2] = 0.9 * CanonLog2_to_linear( bIn );
+
+	// ACES conversion matrix
+	float aces[3];
+
+	aces[0] =   0.678891151 * lin[0] + 0.158868422 * lin[1] + 0.162240427 * lin[2];
+	aces[1] =   0.045570831 * lin[0] + 0.860712772 * lin[1] + 0.093716397 * lin[2];
+	aces[2] = - 0.000485710 * lin[0] + 0.025060196 * lin[1] + 0.975425515 * lin[2];
+
+	rOut = aces[0];
+	gOut = aces[1];
+	bOut = aces[2];
+	aOut = aIn;
+}
+
+/* ============ End of Input Transform ============ */

--- a/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_BT2020_Tng.a1.v2.ctl
+++ b/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_BT2020_Tng.a1.v2.ctl
@@ -1,0 +1,73 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_BT2020_Tng.a1.v2</ACEStransformID>
+// <ACESuserName>ACES 1.0 Input - Canon CanonLog2 BT2020 (Tungsten)</ACESuserName>
+
+/* ********************************************* */
+//
+// Input Transform for Canon Log 2 / BT.2020
+// ACES Version: 1.0
+// IDT Version: 2.0  2021/08/23
+// Copyright(c) 2021 Canon Inc. All Rights Reserved.
+//
+/* ********************************************* */
+//
+// Illuminant   : Tungsten (ISO 7589 Studio Tungsten)
+// Color Gamut  : BT.2020
+// Gamma        : Canon Log 2
+// Color Matrix : Neutral
+//
+// [ NOTE ]
+//
+// This Input Transform is defined for images those were shot
+//  under illumination sources with low color temperature like Tungsten. 
+//
+/* ********************************************* */
+
+
+/* ============ SUBFUNCTIONS ============ */
+/* CanonLog2 to Linear */
+float CanonLog2_to_linear (
+	float clog2
+)
+{
+	float out;
+	if(clog2 < 0.092864125)
+		out = -( pow( 10, ( 0.092864125 - clog2 ) / 0.24136077 ) - 1 ) / 87.099375;
+	else
+		out = ( pow( 10, ( clog2 - 0.092864125 ) / 0.24136077 ) - 1 ) / 87.099375;
+
+	return out;
+}
+
+
+/* ============ Main Algorithm ============ */
+void main
+(   input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+	// CanonLog2 to linear 
+	float lin[3];
+	lin[0] = 0.9 * CanonLog2_to_linear( rIn );
+	lin[1] = 0.9 * CanonLog2_to_linear( gIn );
+	lin[2] = 0.9 * CanonLog2_to_linear( bIn );
+
+	// ACES conversion matrix
+	float aces[3];
+
+	aces[0] = 0.724488568 * lin[0] + 0.115140904 * lin[1] + 0.160370529 * lin[2];
+	aces[1] = 0.010659276 * lin[0] + 0.839605344 * lin[1] + 0.149735380 * lin[2];
+	aces[2] = 0.014560161 * lin[0] - 0.028562057 * lin[1] + 1.014001897 * lin[2];
+
+	rOut = aces[0];
+	gOut = aces[1];
+	bOut = aces[2];
+	aOut = aIn;
+}
+
+/* ============ End of Input Transform ============ */

--- a/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_CinemaGamut_D55.a1.v2.ctl
+++ b/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_CinemaGamut_D55.a1.v2.ctl
@@ -1,0 +1,73 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_CinemaGamut_D55.a1.v2</ACEStransformID>
+// <ACESuserName>ACES 1.0 Input - Canon CanonLog2 CinemaGamut (Daylight)</ACESuserName>
+
+/* ********************************************* */
+//
+// Input Transform for Canon Log 2 / Cinema Gamut
+// ACES Version: 1.0
+// IDT Version: 2.0  2021/08/23
+// Copyright(c) 2021 Canon Inc. All Rights Reserved.
+//
+/* ********************************************* */
+//
+// Illuminant   : Daylight (CIE Illuminant D55)
+// Color Gamut  : Cinema Gamut
+// Gamma        : Canon Log 2
+// Color Matrix : Neutral
+//
+// [ NOTE ]
+//
+// This Input Transform is defined for images those were shot
+//  under daylight and general illumination sources except Tungsten.
+//
+/* ********************************************* */
+
+
+/* ============ SUBFUNCTIONS ============ */
+/* CanonLog2 to Linear */
+float CanonLog2_to_linear (
+	float clog2
+)
+{
+	float out;
+	if(clog2 < 0.092864125)
+		out = -( pow( 10, ( 0.092864125 - clog2 ) / 0.24136077 ) - 1 ) / 87.099375;
+	else
+		out = ( pow( 10, ( clog2 - 0.092864125 ) / 0.24136077 ) - 1 ) / 87.099375;
+
+	return out;
+}
+
+
+/* ============ Main Algorithm ============ */
+void main
+(   input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+	// CanonLog2 to linear 
+	float lin[3];
+	lin[0] = 0.9 * CanonLog2_to_linear( rIn );
+	lin[1] = 0.9 * CanonLog2_to_linear( gIn );
+	lin[2] = 0.9 * CanonLog2_to_linear( bIn );
+
+	// ACES conversion matrix
+	float aces[3];
+
+	aces[0] =   0.763064455 * lin[0] + 0.149021161 * lin[1] + 0.087914384 * lin[2];
+	aces[1] =   0.003657457 * lin[0] + 1.106960380 * lin[1] - 0.110617837 * lin[2];
+	aces[2] = - 0.009407794 * lin[0] - 0.218383305 * lin[1] + 1.227791099 * lin[2];
+
+	rOut = aces[0];
+	gOut = aces[1];
+	bOut = aces[2];
+	aOut = aIn;
+}
+
+/* ============ End of Input Transform ============ */

--- a/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_CinemaGamut_Tng.a1.v2.ctl
+++ b/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog2_CinemaGamut_Tng.a1.v2.ctl
@@ -1,0 +1,73 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog2_CinemaGamut_Tng.a1.v2</ACEStransformID>
+// <ACESuserName>ACES 1.0 Input - Canon CanonLog2 CinemaGamut (Tungsten)</ACESuserName>
+
+/* ********************************************* */
+//
+// Input Transform for Canon Log 2 / Cinema Gamut
+// ACES Version: 1.0
+// IDT Version: 2.0  2021/08/23
+// Copyright(c) 2021 Canon Inc. All Rights Reserved.
+//
+/* ********************************************* */
+//
+// Illuminant   : Tungsten (ISO 7589 Studio Tungsten)
+// Color Gamut  : Cinema Gamut
+// Gamma        : Canon Log 2
+// Color Matrix : Neutral
+//
+// [ NOTE ]
+//
+// This Input Transform is defined for images those were shot
+//  under illumination sources with low color temperature like Tungsten. 
+//
+/* ********************************************* */
+
+
+/* ============ SUBFUNCTIONS ============ */
+/* CanonLog2 to Linear */
+float CanonLog2_to_linear (
+	float clog2
+)
+{
+	float out;
+	if(clog2 < 0.092864125)
+		out = -( pow( 10, ( 0.092864125 - clog2 ) / 0.24136077 ) - 1 ) / 87.099375;
+	else
+		out = ( pow( 10, ( clog2 - 0.092864125 ) / 0.24136077 ) - 1 ) / 87.099375;
+
+	return out;
+}
+
+
+/* ============ Main Algorithm ============ */
+void main
+(   input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+	// CanonLog2 to linear 
+	float lin[3];
+	lin[0] = 0.9 * CanonLog2_to_linear( rIn );
+	lin[1] = 0.9 * CanonLog2_to_linear( gIn );
+	lin[2] = 0.9 * CanonLog2_to_linear( bIn );
+
+	// ACES conversion matrix
+	float aces[3];
+
+	aces[0] =   0.817416293 * lin[0] + 0.090755698 * lin[1] + 0.091828009 * lin[2];
+	aces[1] = - 0.035361374 * lin[0] + 1.065690585 * lin[1] - 0.030329211 * lin[2];
+	aces[2] =   0.010390366 * lin[0] - 0.299271107 * lin[1] + 1.288880741 * lin[2];
+
+	rOut = aces[0];
+	gOut = aces[1];
+	bOut = aces[2];
+	aOut = aIn;
+}
+
+/* ============ End of Input Transform ============ */

--- a/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_BT2020_D55.a1.v2.ctl
+++ b/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_BT2020_D55.a1.v2.ctl
@@ -1,0 +1,75 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_BT2020_D55.a1.v2</ACEStransformID>
+// <ACESuserName>ACES 1.0 Input - Canon CanonLog3 BT2020 (Daylight)</ACESuserName>
+
+/* ********************************************* */
+//
+// Input Transform for Canon Log 3 / BT.2020
+// ACES Version: 1.0
+// IDT Version: 2.0  2021/08/23
+// Copyright(c) 2021 Canon Inc. All Rights Reserved.
+//
+/* ********************************************* */
+//
+// Illuminant   : Daylight (CIE Illuminant D55)
+// Color Gamut  : BT.2020
+// Gamma        : Canon Log 3
+// Color Matrix : Neutral
+//
+// [ NOTE ]
+//
+// This Input Transform is defined for images those were shot
+//  under daylight and general illumination sources except Tungsten.
+//
+/* ********************************************* */
+
+
+/* ============ SUBFUNCTIONS ============ */
+/* CanonLog3 to Linear */
+float CanonLog3_to_linear (
+	float clog3
+)
+{
+	float out;
+	if(clog3 < 0.097465473)
+		out = -( pow( 10, ( 0.12783901 - clog3 ) / 0.36726845 ) - 1 ) / 14.98325;
+	else if(clog3 <= 0.15277891)
+		out = ( clog3 - 0.12512219 ) / 1.9754798;
+	else
+		out = ( pow( 10, ( clog3 - 0.12240537 ) / 0.36726845 ) - 1 ) / 14.98325;
+
+	return out;
+}
+
+
+/* ============ Main Algorithm ============ */
+void main
+(   input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+	// CanonLog3 to linear 
+	float lin[3];
+	lin[0] = 0.9 * CanonLog3_to_linear( rIn );
+	lin[1] = 0.9 * CanonLog3_to_linear( gIn );
+	lin[2] = 0.9 * CanonLog3_to_linear( bIn );
+
+	// ACES conversion matrix
+	float aces[3];
+
+	aces[0] =   0.678891151 * lin[0] + 0.158868422 * lin[1] + 0.162240427 * lin[2];
+	aces[1] =   0.045570831 * lin[0] + 0.860712772 * lin[1] + 0.093716397 * lin[2];
+	aces[2] = - 0.000485710 * lin[0] + 0.025060196 * lin[1] + 0.975425515 * lin[2];
+
+	rOut = aces[0];
+	gOut = aces[1];
+	bOut = aces[2];
+	aOut = aIn;
+}
+
+/* ============ End of Input Transform ============ */

--- a/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_BT2020_Tng.a1.v2.ctl
+++ b/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_BT2020_Tng.a1.v2.ctl
@@ -1,0 +1,75 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_BT2020_Tng.a1.v2</ACEStransformID>
+// <ACESuserName>ACES 1.0 Input - Canon CanonLog3 BT2020 (Tungsten)</ACESuserName>
+
+/* ********************************************* */
+//
+// Input Transform for Canon Log 3 / BT.2020
+// ACES Version: 1.0
+// IDT Version: 2.0  2021/08/23
+// Copyright(c) 2021 Canon Inc. All Rights Reserved.
+//
+/* ********************************************* */
+//
+// Illuminant   : Tungsten (ISO 7589 Studio Tungsten)
+// Color Gamut  : BT.2020
+// Gamma        : Canon Log 3
+// Color Matrix : Neutral
+//
+// [ NOTE ]
+//
+// This Input Transform is defined for images those were shot
+//  under illumination sources with low color temperature like Tungsten. 
+//
+/* ********************************************* */
+
+
+/* ============ SUBFUNCTIONS ============ */
+/* CanonLog3 to Linear */
+float CanonLog3_to_linear (
+	float clog3
+)
+{
+	float out;
+	if(clog3 < 0.097465473)
+		out = -( pow( 10, ( 0.12783901 - clog3 ) / 0.36726845 ) - 1 ) / 14.98325;
+	else if(clog3 <= 0.15277891)
+		out = ( clog3 - 0.12512219 ) / 1.9754798;
+	else
+		out = ( pow( 10, ( clog3 - 0.12240537 ) / 0.36726845 ) - 1 ) / 14.98325;
+
+	return out;
+}
+
+
+/* ============ Main Algorithm ============ */
+void main
+(   input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+	// CanonLog3 to linear 
+	float lin[3];
+	lin[0] = 0.9 * CanonLog3_to_linear( rIn );
+	lin[1] = 0.9 * CanonLog3_to_linear( gIn );
+	lin[2] = 0.9 * CanonLog3_to_linear( bIn );
+
+	// ACES conversion matrix
+	float aces[3];
+
+	aces[0] = 0.724488568 * lin[0] + 0.115140904 * lin[1] + 0.160370529 * lin[2];
+	aces[1] = 0.010659276 * lin[0] + 0.839605344 * lin[1] + 0.149735380 * lin[2];
+	aces[2] = 0.014560161 * lin[0] - 0.028562057 * lin[1] + 1.014001897 * lin[2];
+
+	rOut = aces[0];
+	gOut = aces[1];
+	bOut = aces[2];
+	aOut = aIn;
+}
+
+/* ============ End of Input Transform ============ */

--- a/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_CinemaGamut_D55.a1.v2.ctl
+++ b/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_CinemaGamut_D55.a1.v2.ctl
@@ -1,0 +1,75 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_CinemaGamut_D55.a1.v2</ACEStransformID>
+// <ACESuserName>ACES 1.0 Input - Canon CanonLog3 CinemaGamut (Daylight)</ACESuserName>
+
+/* ********************************************* */
+//
+// Input Transform for Canon Log 3 / Cinema Gamut
+// ACES Version: 1.0
+// IDT Version: 2.0  2021/08/23
+// Copyright(c) 2021 Canon Inc. All Rights Reserved.
+//
+/* ********************************************* */
+//
+// Illuminant   : Daylight (CIE Illuminant D55)
+// Color Gamut  : Cinema Gamut
+// Gamma        : Canon Log 3
+// Color Matrix : Neutral
+//
+// [ NOTE ]
+//
+// This Input Transform is defined for images those were shot
+//  under daylight and general illumination sources except Tungsten.
+//
+/* ********************************************* */
+
+
+/* ============ SUBFUNCTIONS ============ */
+/* CanonLog3 to Linear */
+float CanonLog3_to_linear (
+	float clog3
+)
+{
+	float out;
+	if(clog3 < 0.097465473)
+		out = -( pow( 10, ( 0.12783901 - clog3 ) / 0.36726845 ) - 1 ) / 14.98325;
+	else if(clog3 <= 0.15277891)
+		out = ( clog3 - 0.12512219 ) / 1.9754798;
+	else
+		out = ( pow( 10, ( clog3 - 0.12240537 ) / 0.36726845 ) - 1 ) / 14.98325;
+
+	return out;
+}
+
+
+/* ============ Main Algorithm ============ */
+void main
+(   input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+	// CanonLog3 to linear 
+	float lin[3];
+	lin[0] = 0.9 * CanonLog3_to_linear( rIn );
+	lin[1] = 0.9 * CanonLog3_to_linear( gIn );
+	lin[2] = 0.9 * CanonLog3_to_linear( bIn );
+
+	// ACES conversion matrix
+	float aces[3];
+
+	aces[0] =   0.763064455 * lin[0] + 0.149021161 * lin[1] + 0.087914384 * lin[2];
+	aces[1] =   0.003657457 * lin[0] + 1.106960380 * lin[1] - 0.110617837 * lin[2];
+	aces[2] = - 0.009407794 * lin[0] - 0.218383305 * lin[1] + 1.227791099 * lin[2];
+
+	rOut = aces[0];
+	gOut = aces[1];
+	bOut = aces[2];
+	aOut = aIn;
+}
+
+/* ============ End of Input Transform ============ */

--- a/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_CinemaGamut_Tng.a1.v2.ctl
+++ b/transforms/ctl/idt/vendorSupplied/canon/IDT.Canon.CanonLog3_CinemaGamut_Tng.a1.v2.ctl
@@ -1,0 +1,75 @@
+// <ACEStransformID>urn:ampas:aces:transformId:v1.5:IDT.Canon.CanonLog3_CinemaGamut_Tng.a1.v2</ACEStransformID>
+// <ACESuserName>ACES 1.0 Input - Canon CanonLog3 CinemaGamut (Tungsten)</ACESuserName>
+
+/* ********************************************* */
+//
+// Input Transform for Canon Log 3 / Cinema Gamut
+// ACES Version: 1.0
+// IDT Version: 2.0  2021/08/23
+// Copyright(c) 2021 Canon Inc. All Rights Reserved.
+//
+/* ********************************************* */
+//
+// Illuminant   : Tungsten (ISO 7589 Studio Tungsten)
+// Color Gamut  : Cinema Gamut
+// Gamma        : Canon Log 3
+// Color Matrix : Neutral
+//
+// [ NOTE ]
+//
+// This Input Transform is defined for images those were shot
+//  under illumination sources with low color temperature like Tungsten. 
+//
+/* ********************************************* */
+
+
+/* ============ SUBFUNCTIONS ============ */
+/* CanonLog3 to Linear */
+float CanonLog3_to_linear (
+	float clog3
+)
+{
+	float out;
+	if(clog3 < 0.097465473)
+		out = -( pow( 10, ( 0.12783901 - clog3 ) / 0.36726845 ) - 1 ) / 14.98325;
+	else if(clog3 <= 0.15277891)
+		out = ( clog3 - 0.12512219 ) / 1.9754798;
+	else
+		out = ( pow( 10, ( clog3 - 0.12240537 ) / 0.36726845 ) - 1 ) / 14.98325;
+
+	return out;
+}
+
+
+/* ============ Main Algorithm ============ */
+void main
+(   input varying float rIn,
+    input varying float gIn,
+    input varying float bIn,
+    input varying float aIn,
+    output varying float rOut,
+    output varying float gOut,
+    output varying float bOut,
+    output varying float aOut
+)
+{
+	// CanonLog3 to linear 
+	float lin[3];
+	lin[0] = 0.9 * CanonLog3_to_linear( rIn );
+	lin[1] = 0.9 * CanonLog3_to_linear( gIn );
+	lin[2] = 0.9 * CanonLog3_to_linear( bIn );
+
+	// ACES conversion matrix
+	float aces[3];
+
+	aces[0] =   0.817416293 * lin[0] + 0.090755698 * lin[1] + 0.091828009 * lin[2];
+	aces[1] = - 0.035361374 * lin[0] + 1.065690585 * lin[1] - 0.030329211 * lin[2];
+	aces[2] =   0.010390366 * lin[0] - 0.299271107 * lin[1] + 1.288880741 * lin[2];
+
+	rOut = aces[0];
+	gOut = aces[1];
+	bOut = aces[2];
+	aOut = aIn;
+}
+
+/* ============ End of Input Transform ============ */

--- a/transforms/ctl/idt/vendorSupplied/canon/LegacyIDTs.md
+++ b/transforms/ctl/idt/vendorSupplied/canon/LegacyIDTs.md
@@ -1,0 +1,22 @@
+# Legacy IDTs
+
+Select legacy IDTs are published at the following links: <br>
+(set OS to Windows)
+
+* [EOS C100](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c100)
+* [EOS C100 Mark II](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c100-mark-ii)
+* [EOS C200](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c200)
+* [EOS C200B](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c200b)
+* [EOS C300](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300)
+* [EOS C300 PL](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-pl)
+* [EOS C300 Mark II](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii)
+* [EOS C300 Mark II PL](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii-pl)
+* [EOS C500](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c500)
+* [EOS C500 PL](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c500-pl)
+* [EOS C700](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700)
+* [EOS C700 FF](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700-ff)
+* [EOS C700 FF PL](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700-ff-pl)
+* [EOS C700 GS PL](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700-gs-pl)
+* [EOS C700 PL](https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700-pl)
+
+Note: There is no difference in the resulting image between the latest IDTs and legacy IDTs. Replacing legacy IDTs with the latest IDTs for the same color space should result in the same ACES image.

--- a/transforms/ctl/idt/vendorSupplied/canon/README.md
+++ b/transforms/ctl/idt/vendorSupplied/canon/README.md
@@ -22,6 +22,7 @@ The latest IDTs are available for the following models:
 * EOS-1D X Mark III
 * EOS R3
 * EOS R5
+* EOS R5 C
 * EOS R6
 * and models released after 2022.
 

--- a/transforms/ctl/idt/vendorSupplied/canon/README.md
+++ b/transforms/ctl/idt/vendorSupplied/canon/README.md
@@ -1,1 +1,28 @@
-Canon Input Device Transform (IDT) files are published on the following websites. Set "OS Version" to Windows 7 to see them.* Canon EOS C100 - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c100* Canon EOS C100 Mark II - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c100-mark-ii* Canon EOS C200 - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c200* Canon EOS C200B - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c200b* Canon EOS C300 - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300* Canon EOS C300 PL - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-pl* Canon EOS C300 Mark II - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii* Canon EOS C300 Mark II PL -https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c300-mark-ii-pl* Canon EOS C500 - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c500* Canon EOS C500 PL - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c500-pl* Canon EOS C500 Mark II - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/cinema-eos-c500-mark-ii* Canon EOS C700 - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700* Canon EOS C700 FF - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700-ff* Canon EOS C700 FF PL - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700-ff-pl* Canon EOS C700 GS PL - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700-gs-pl* Canon EOS C700 PL - https://www.usa.canon.com/internet/portal/us/home/support/details/cameras/cinema-eos/eos-c700-pl
+# Latest IDTs
+
+The latest Canon IDTs are provided here and have been unified to be classified by color space (rather than per camera).
+* Supported gamma : **Canon Log 2**, **Canon Log 3**
+* Supported color gamut : **Cinema Gamut**, **BT.2020 Gamut**
+
+Note: There is no difference in the resulting image between the latest IDTs and legacy IDTs. Replacing legacy IDTs with the latest IDTs for the same color space should result in the same ACES image.
+
+The latest IDTs are available for the following models:
+* EOS C70
+* EOS C200
+* EOS C200B
+* EOS C300 Mark II
+* EOS C300 Mark II PL
+* EOS C300 Mark III
+* EOS C500 Mark II
+* EOS C700
+* EOS C700 FF
+* EOS C700 FF PL
+* EOS C700 GS PL
+* EOS C700 PL
+* EOS-1D X Mark III
+* EOS R3
+* EOS R5
+* EOS R6
+* and models released after 2022.
+
+These latest IDTs are for Canon Log 2 or Canon Log 3, so if you need IDTs for Canon Log, see [“LegacyIDTs.md”](LegacyIDTs.md)


### PR DESCRIPTION
Canon had previously provided per-camera IDTs. However, each were defined for the same color space, making them effectively the same other than in title. This commit unifies the IDTs by color space rather than per camera, reducing the number of redundant IDTs.

It also adds the CTL versions of the latest IDTs to aces-dev, keeping the previous links to the legacy IDTs that remain hosted on Canon's site.